### PR TITLE
Updated to v1.1.0 from origin repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ This is Openwall's [Phpass](http://openwall.com/phpass/), based on the 0.3 relea
 
 The changes are minimal and only stylistic. The source code is in the public domain. We claim no ownership, but needed it for one of our projects, and wanted to make it available to other people as well. 
 
+* `1.1.0` - Modified to add `random_bytes` hook function.
+* `1.0.0` - Modified to use [hash_equals](http://php.net/hash_equals) to be resistant to timing attacks. This requires `php >= 5.6.0`.
+* `0.3.x` - Very close to the original version. Requires `php >= 5.3.3`.
+
+## Customizing the Source of Randomness
+
+In version `1.1.0`, the `get_random_bytes` function checks for the presence of a `random_bytes` function. If a `random_bytes` function is callable, then `random_bytes` will be used as the source for random bytes output. Otherwise, the original `get_random_bytes` code will be used.
+
 ## Installation ##
 
 Add this requirement to your `composer.json` file and run `composer.phar install`:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "password",
     "security"
   ],
-  "homepage": "http://github.com/hautelook/phpass/",
+  "homepage": "http://github.com/bordoni/phpass/",
   "authors": [
     {
       "name": "Solar Designer",
@@ -24,7 +24,7 @@
     }
   ],
   "require": {
-    "php": ">=5.3.3"
+    "php": ">=5.6.0"
   },
   "autoload": {
     "psr-0": {
@@ -32,6 +32,6 @@
     }
   },
   "replace": {
-    "hautelook/phpass": "0.3.*"
+    "hautelook/phpass": "1.1.0"
   }
 }

--- a/src/Hautelook/Phpass/PasswordHash.php
+++ b/src/Hautelook/Phpass/PasswordHash.php
@@ -6,7 +6,12 @@ namespace Hautelook\Phpass;
  *
  * Portable PHP password hashing framework.
  *
- * Version 0.3 / genuine.
+ * Version 1.0.0 - modified by Nordstromrack.com | HauteLook
+ *
+ * Change Log:
+ *
+ * - the hash_equals function is now used instead of == or === to prevent
+ *   timing attacks
  *
  * Written by Solar Designer <solar at openwall.com> in 2004-2006 and placed in
  *
@@ -314,6 +319,6 @@ class PasswordHash
             $hash = crypt($password, $stored_hash);
         }
 
-        return $hash === $stored_hash;
+        return hash_equals($stored_hash, $hash);
     }
 }


### PR DESCRIPTION
I just ran into the issue of the old repository being deleted. It seems that your fork was not quite up to date, so I have picked on of my previous installs and integrated the changes into your repository. This should satisfy the old composer requirement of `"hautelook/phpass": "^1.1"`

See the still existing page on packagist.org: https://packagist.org/packages/hautelook/phpass