### PR TITLE
Fix Implicit incompatible float issue in php-8.1

### DIFF
--- a/src/Hautelook/Phpass/PasswordHash.php
+++ b/src/Hautelook/Phpass/PasswordHash.php
@@ -230,7 +230,7 @@ class PasswordHash
         $itoa64 = './ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
         $output = '$2a$';
-        $output .= chr(ord('0') + $this->iteration_count_log2 / 10);
+        $output .= chr(ord('0') + intval($this->iteration_count_log2 / 10));
         $output .= chr(ord('0') + $this->iteration_count_log2 % 10);
         $output .= '$';
 


### PR DESCRIPTION
# Changed log

- Using the `intval` to cast the type to integer and  avoid getting the `PHP Deprecated:  Implicit conversion from float` issue in `php-8.1`.

# Reproducing issue

- Here are the steps to reproduce above issue:
- Prepare the PHP 8.1 version.
- Using the `git` command to clone the repository.
- Using the `composer install` command to create the `vendor` directory and `vendor/autoload.php` file.
- Create the `hash.php` to fill following codes:

```php
<?php
error_reporting(E_ALL);

require_once './vendor/autoload.php';

use Hautelook\Phpass\PasswordHash;

$passwordHasher = new PasswordHash(8, false);
$password = $passwordHasher->HashPassword('secret');
var_dump($password);
```

- Running the above `hash.php` with `php8.1`.

## Expected

```php
string(60) "$2a$08$ZxqWDNbGqmpyMiQr8CFrFuNyJ9574VenWMnRtVHQFK9CtYNqP5hZq"
```

## Actual

```php
PHP Deprecated:  Implicit conversion from float 48.8 to int loses precision in /home/peterli/phpass/src/Hautelook/Phpass/PasswordHash.php on line 233
string(60) "$2a$08$ZxqWDNbGqmpyMiQr8CFrFuNyJ9574VenWMnRtVHQFK9CtYNqP5hZq"
```